### PR TITLE
Aiosqlite 0.21.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "aiosqlite" %}
-{% set version = "0.18.0" %}
-{% set sha256 = "faa843ef5fb08bafe9a9b3859012d3d9d6f77ce3637899de20606b7fc39aa213" %}
+{% set version = "0.21.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,21 +7,26 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3
 
 build:
   number: 0
-  skip: true # [py<38]
+  skip: true # [py<39]
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
 
 requirements:
   host:
     - python
     - pip
-    - flit-core >=2,<4
+    - flit-core >=3.8,<4
     - wheel
   run:
     - python
+    - typing_extensions >=4.0
+  run_constrained:
+    - mypy==1.14.1
+    - black==24.3.0
+    - flake8==7.0.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,10 +23,6 @@ requirements:
   run:
     - python
     - typing_extensions >=4.0
-  run_constrained:
-    - mypy==1.14.1
-    - black==24.3.0
-    - flake8==7.0.0
 
 test:
   imports:


### PR DESCRIPTION
> ## ☆ Aiosqlite 0.21.0 ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-6551) 
[Upstream](https://github.com/omnilib/aiosqlite)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `run_constrained` 
> * Added skip to python versions less than 3.9
> *  Minor updated formatting